### PR TITLE
Add 'current' case to ipmi module

### DIFF
--- a/plugin/ipmi.php
+++ b/plugin/ipmi.php
@@ -37,6 +37,11 @@ switch($obj->args['type']) {
 		$obj->rrd_vertical = 'Volt';
 		$obj->rrd_format = '%5.1lf';
 	break;
+	case 'current':
+		$obj->rrd_title = sprintf('Current (%s)', $obj->args['pinstance']);
+		$obj->rrd_vertical = 'Ampere';
+		$obj->rrd_format = '%5.1lf';
+	break;
 }
 
 collectd_flush($obj->identifiers);


### PR DESCRIPTION
Some ipmi Hardware has the ability so sense current, so a case for that is added.
