### PR TITLE
DIR_FSROOT

### DIFF
--- a/config/config.php.tpl
+++ b/config/config.php.tpl
@@ -20,8 +20,9 @@ define('LDAP_PORT','');
 ## Tree : ou=People,dc=domain,dc=com
 define('LDAP_TREE','');
  
-# Filesystem path to cgraphz (ex: /var/www/cgraphz)
-define('DIR_FSROOT',$_SERVER['DOCUMENT_ROOT'].'/CGraphz');
+# Filesystem path to cgraphz (ex: /var/www/cgraphz).
+# leave it as defined unless you know what you do.
+define('DIR_FSROOT',realpath(__DIR__.'/../'));
 
 # Dir web root (http://mydomain.com/XXXXXX : /XXXXXX)
 define('DIR_WEBROOT', '/CGraphz');


### PR DESCRIPTION
Define DIR_FSROOT as realpath(**DIR**.'/../') this way new users do not
need to adopt it
